### PR TITLE
Explorer config JSON fix

### DIFF
--- a/config/gen3/explorer.json
+++ b/config/gen3/explorer.json
@@ -141,7 +141,8 @@
         "subject_id": {
           "title": "Subject ID"
         }
-      },
+      }
+    },
     "guppyConfig": {
       "dataType": "imaging_study",
       "nodeCountTitle": "Imaging Studies",


### PR DESCRIPTION
Fixing malformed explorer.json; first tab's "table" section was missing its closing bracket.